### PR TITLE
Feature/16 HomeView와 PostView 연결

### DIFF
--- a/Careerly/Careerly.xcodeproj/project.pbxproj
+++ b/Careerly/Careerly.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E473586223750D52152EEF4 /* Pods_Careerly.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7755FFF874B1A45EA76E292C /* Pods_Careerly.framework */; };
 		23246F592833BF16004A46C5 /* UITextField++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23246F582833BF16004A46C5 /* UITextField++.swift */; };
 		234C4936282FD50B009747B2 /* Post.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 234C4935282FD50B009747B2 /* Post.storyboard */; };
 		2352AEB12832ADAA0043D932 /* PostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2352AEB02832ADAA0043D932 /* PostViewController.swift */; };
@@ -19,7 +20,6 @@
 		23E4726C28354802003B0BF8 /* PostDetailTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E4726A28354802003B0BF8 /* PostDetailTVC.swift */; };
 		23E4726D28354802003B0BF8 /* PostDetailTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = 23E4726B28354802003B0BF8 /* PostDetailTVC.xib */; };
 		23E71EC02834027400D638B5 /* UIColor++.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23E71EBF2834027400D638B5 /* UIColor++.swift */; };
-		0E473586223750D52152EEF4 /* Pods_Careerly.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7755FFF874B1A45EA76E292C /* Pods_Careerly.framework */; };
 		CE05BC752835240B007D3CA3 /* FeedTVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE05BC732835240B007D3CA3 /* FeedTVC.swift */; };
 		CE05BC762835240B007D3CA3 /* FeedTVC.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE05BC742835240B007D3CA3 /* FeedTVC.xib */; };
 		CE4CDE702833E16C002BBB4D /* HomeTabVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4CDE6F2833E16C002BBB4D /* HomeTabVC.swift */; };
@@ -293,10 +293,10 @@
 		CECC9394282FBDDB00432906 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				CECC939B282FBE8200432906 /* Home */,
 				23E4726928354697003B0BF8 /* Detail */,
 				234C4932282FD494009747B2 /* Post */,
 				CECC939C282FBE8600432906 /* Guide */,
-				CECC939B282FBE8200432906 /* Home */,
 				CECC939A282FBE7D00432906 /* Base */,
 			);
 			path = Screens;

--- a/Careerly/Careerly/Info.plist
+++ b/Careerly/Careerly/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>Post</string>
+					<string>TabBar</string>
 				</dict>
 			</array>
 		</dict>

--- a/Careerly/Careerly/Screens/Detail/PostDetail.storyboard
+++ b/Careerly/Careerly/Screens/Detail/PostDetail.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,7 +11,7 @@
         <!--Post Detail View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController storyboardIdentifier="PostDetail" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" customClass="PostDetailViewController" customModule="Careerly" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PostDetailViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" customClass="PostDetailViewController" customModule="Careerly" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTab.storyboard
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTab.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="kri-Na-r44">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="mX1-rN-rkf">
-                                <rect key="frame" x="0.0" y="44" width="390" height="717"/>
+                                <rect key="frame" x="0.0" y="88" width="390" height="673"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             </tableView>
                         </subviews>
@@ -30,13 +30,32 @@
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="mX1-rN-rkf" secondAttribute="bottom" id="wTd-PY-Gqb"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="" image="icon_home" selectedImage="icon_home" id="feh-6C-ONK"/>
+                    <navigationItem key="navigationItem" id="GnC-Wx-s06"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="tableView" destination="mX1-rN-rkf" id="rVf-Qi-GAm"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1060" y="109.47867298578198"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="A2K-iq-ezr">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="kri-Na-r44" sceneMemberID="viewController">
+                    <tabBarItem key="tabBarItem" title="" image="icon_home" selectedImage="icon_home" id="feh-6C-ONK"/>
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="E36-kl-B8Y">
+                        <rect key="frame" x="0.0" y="44" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="Y6W-OH-hqX" kind="relationship" relationship="rootViewController" id="Ndb-Y7-1o1"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="bmK-Qo-T7m" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="130.76923076923077" y="109.47867298578198"/>
         </scene>

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTabVC.swift
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTabVC.swift
@@ -110,3 +110,4 @@ extension HomeTabVC: FeedTVCDelegate {
         navigationController?.pushViewController(postDetailVC, animated: true)
     }
 }
+ 

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTabVC.swift
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTabVC.swift
@@ -21,6 +21,14 @@ class HomeTabVC: UIViewController {
         configureNavigationBar()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        tabBarController?.tabBar.isHidden = false
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        tabBarController?.tabBar.isHidden = true
+    }
+    
     // MARK: - Custom Method Part
     func setDelegate() {
         tableView.delegate = self
@@ -84,14 +92,23 @@ extension HomeTabVC: UITableViewDataSource {
             withIdentifier: FeedTVC.identifier,
             for: indexPath) as? FeedTVC
         else { return UITableViewCell()}
+        feedCell.delegate = self
         
         return feedCell
     }
 }
 
 extension HomeTabVC: TableViewHeaderViewDelegate {
-    func presentPostView() {
+    func showPostView() {
         guard let postVC = UIStoryboard(name: "Post", bundle: nil).instantiateViewController(withIdentifier: "PostViewController") as? PostViewController else { return }
         navigationController?.pushViewController(postVC, animated: true)
+    }
+}
+
+extension HomeTabVC: FeedTVCDelegate {
+    func showPostDetailView() {
+        guard let postDetailVC = UIStoryboard(name: "PostDetail", bundle: nil).instantiateViewController(withIdentifier: "PostDetailViewController") as? PostDetailViewController else { return }
+        postDetailVC.postText = "sample text"
+        navigationController?.pushViewController(postDetailVC, animated: true)
     }
 }

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTabVC.swift
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTabVC.swift
@@ -18,6 +18,7 @@ class HomeTabVC: UIViewController {
         
         setDelegate()
         configureTableView()
+        configureNavigationBar()
     }
     
     // MARK: - Custom Method Part
@@ -31,10 +32,15 @@ class HomeTabVC: UIViewController {
         registerCell()
     }
     
+    func configureNavigationBar() {
+        navigationController?.isNavigationBarHidden = true
+    }
+    
     func configureTableViewHeader() {
         // TableView 헤더 설정
         let headerNib = UINib(nibName: TableViewHeaderView.identifier, bundle: nil)
-        guard let headerView = headerNib.instantiate(withOwner: self).first as? UIView else { return }
+        guard let headerView = headerNib.instantiate(withOwner: self).first as? TableViewHeaderView else { return }
+        headerView.delegate = self
         headerView.translatesAutoresizingMaskIntoConstraints = false
         headerView.widthAnchor.constraint(equalToConstant: view.frame.width).isActive = true
         
@@ -80,5 +86,12 @@ extension HomeTabVC: UITableViewDataSource {
         else { return UITableViewCell()}
         
         return feedCell
+    }
+}
+
+extension HomeTabVC: TableViewHeaderViewDelegate {
+    func presentPostView() {
+        guard let postVC = UIStoryboard(name: "Post", bundle: nil).instantiateViewController(withIdentifier: "PostViewController") as? PostViewController else { return }
+        navigationController?.pushViewController(postVC, animated: true)
     }
 }

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTabVC.swift
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/HomeTabVC.swift
@@ -25,10 +25,6 @@ class HomeTabVC: UIViewController {
         tabBarController?.tabBar.isHidden = false
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        tabBarController?.tabBar.isHidden = true
-    }
-    
     // MARK: - Custom Method Part
     func setDelegate() {
         tableView.delegate = self
@@ -101,6 +97,7 @@ extension HomeTabVC: UITableViewDataSource {
 extension HomeTabVC: TableViewHeaderViewDelegate {
     func showPostView() {
         guard let postVC = UIStoryboard(name: "Post", bundle: nil).instantiateViewController(withIdentifier: "PostViewController") as? PostViewController else { return }
+        tabBarController?.tabBar.isHidden = true
         navigationController?.pushViewController(postVC, animated: true)
     }
 }
@@ -109,6 +106,7 @@ extension HomeTabVC: FeedTVCDelegate {
     func showPostDetailView() {
         guard let postDetailVC = UIStoryboard(name: "PostDetail", bundle: nil).instantiateViewController(withIdentifier: "PostDetailViewController") as? PostDetailViewController else { return }
         postDetailVC.postText = "sample text"
+        tabBarController?.tabBar.isHidden = true
         navigationController?.pushViewController(postDetailVC, animated: true)
     }
 }

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/FeedTVC/FeedTVC.swift
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/FeedTVC/FeedTVC.swift
@@ -7,9 +7,14 @@
 
 import UIKit
 
+protocol FeedTVCDelegate: AnyObject {
+    func showPostDetailView()
+}
+
 class FeedTVC: UITableViewCell {
     // MARK: - Vars & Lets Part
     static let identifier = "FeedTVC"
+    weak var delegate: FeedTVCDelegate?
     
     var indexPath: Int?
     
@@ -17,5 +22,11 @@ class FeedTVC: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
     }
-
+    
+    
+    // MARK: - @IBAction Part
+    @IBAction func commentBtnTap(_ sender: UIButton) {
+        delegate?.showPostDetailView()
+    }
+    
 }

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/FeedTVC/FeedTVC.xib
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/FeedTVC/FeedTVC.xib
@@ -148,6 +148,9 @@
                                         <rect key="frame" x="0.0" y="0.0" width="32.5" height="32"/>
                                         <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                         <state key="normal" image="icon_message"/>
+                                        <connections>
+                                            <action selector="commentBtnTap:" destination="KGk-i7-Jjw" eventType="touchUpInside" id="fcz-MZ-g7J"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dj7-Fu-oq3">
                                         <rect key="frame" x="42.5" y="0.0" width="32.5" height="32"/>

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/FeedTVC/FeedTVC.xib
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/FeedTVC/FeedTVC.xib
@@ -79,7 +79,7 @@
                             <constraint firstItem="QRH-8q-nhC" firstAttribute="leading" secondItem="ToM-0T-Lwm" secondAttribute="leading" id="rqX-aT-vHX"/>
                         </constraints>
                     </view>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="내용" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l0F-nu-7QT">
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="내용" lineBreakMode="tailTruncation" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l0F-nu-7QT">
                         <rect key="frame" x="17" y="85" width="416" height="65"/>
                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                         <nil key="textColor"/>

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/TableViewHeader/TableViewHeaderView.swift
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/TableViewHeader/TableViewHeaderView.swift
@@ -7,14 +7,19 @@
 
 import UIKit
 
+protocol TableViewHeaderViewDelegate: AnyObject {
+    func presentPostView()
+}
+
 final class TableViewHeaderView: UIView {
     
     // MARK: - Vars & Lets Part
     static let identifier: String = String(describing: TableViewHeaderView.self)
+    weak var delegate: TableViewHeaderViewDelegate?
     
     // MARK: - @IBAction Part
     @IBAction func postFeedBtnDidTap(_ sender: UIButton) {
         // feed 작성 화면으로 이동
-        print("Debug: Tapped")
+        delegate?.presentPostView()
     }
 }

--- a/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/TableViewHeader/TableViewHeaderView.swift
+++ b/Careerly/Careerly/Screens/Home/TabBar/HomeTab/TableViewComponents/TableViewHeader/TableViewHeaderView.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol TableViewHeaderViewDelegate: AnyObject {
-    func presentPostView()
+    func showPostView()
 }
 
 final class TableViewHeaderView: UIView {
@@ -20,6 +20,6 @@ final class TableViewHeaderView: UIView {
     // MARK: - @IBAction Part
     @IBAction func postFeedBtnDidTap(_ sender: UIButton) {
         // feed 작성 화면으로 이동
-        delegate?.presentPostView()
+        delegate?.showPostView()
     }
 }

--- a/Careerly/Careerly/Screens/Post/Post.storyboard
+++ b/Careerly/Careerly/Screens/Post/Post.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -77,6 +77,9 @@
                                         </constraints>
                                         <state key="normal" title="Button"/>
                                         <buttonConfiguration key="configuration" style="plain" image="btn_back"/>
+                                        <connections>
+                                            <action selector="backBtnTap:" destination="Y6W-OH-hqX" eventType="touchUpInside" id="9dU-wG-Cd2"/>
+                                        </connections>
                                     </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="게시물 작성" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="777-4k-fjZ">
                                         <rect key="frame" x="154" y="23" width="82.333333333333314" height="21.666666666666671"/>

--- a/Careerly/Careerly/Screens/Post/PostViewController.swift
+++ b/Careerly/Careerly/Screens/Post/PostViewController.swift
@@ -86,6 +86,9 @@ class PostViewController: UIViewController {
         self.present(postDetailVC, animated: true)
     }
     
+    @IBAction func backBtnTap(_ sender: UIButton) {
+        navigationController?.popViewController(animated: true)
+    }
 }
 
 // MARK: - Extension Part

--- a/Careerly/Careerly/Screens/Post/PostViewController.swift
+++ b/Careerly/Careerly/Screens/Post/PostViewController.swift
@@ -77,7 +77,7 @@ class PostViewController: UIViewController {
     // MARK: - @IBAction Part
     @IBAction func successBtnTap(_ sender: Any) {
         let storyboard: UIStoryboard? = UIStoryboard(name: "PostDetail", bundle: Bundle.main)
-        guard let postDetailVC = storyboard?.instantiateViewController(identifier: "PostDetail") as? PostDetailViewController else {
+        guard let postDetailVC = storyboard?.instantiateViewController(identifier: "PostDetailViewController") as? PostDetailViewController else {
             return
         }
         


### PR DESCRIPTION
## 🌱 작업한 내용
<!-- 아래 리스트를 지우고, 작업 내용을 적어주세요. -->
- HomeView와 PostView 연결
- HomeView와 PostDetailView 연결

## 🌱 PR Point
<!-- 피드백을 받고 싶은 부분이나, 공유하고 싶은 부분을 적어주세요. -->
- headerView에서 버튼 클릭 시 곧바로 화면 전환은 불가능해서 protocol-delegate 를 이용하여 HomeView에서 postView를 NavigatoinController에 push하는 방식을 사용했습니다!
- ~TableView에서 각 Feed를 터치했을 때 PostDetail 뷰로의 화면 전환은 데이터 모델이 있어야 해서 서버 통신 코드 구현하고 연결하면 될 것 같습니다. (더미 데이터 넣으면 되기는 하는데 졸려서..)~
- 대충 아무 스트링 넣어서 댓글 버튼 누르면 PostDetailView로 가지게 했습니다.
- 몰랐는데 피그마 보니까 PostView랑 PostDetailView에서는 탭바가 사라져야해서 hidden처리 했습니다.





## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면 전환 |  ![Simulator Screen Recording - iPhone 13 mini - 2022-05-25 at 02 53 14](https://user-images.githubusercontent.com/77267404/170100755-e51162d6-8cf1-4611-b4ae-41fa590ce77c.gif)  |



## 📮 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
- Resolved: #16 
