### PR TITLE
[CHORE] : detail view ui 수정

### DIFF
--- a/Careerly/Careerly/Screens/Detail/Comment/PostCommentTVC.xib
+++ b/Careerly/Careerly/Screens/Detail/Comment/PostCommentTVC.xib
@@ -3,6 +3,7 @@
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -10,14 +11,14 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="KGk-i7-Jjw" customClass="PostCommentTVC" customModule="Careerly" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="395" height="157"/>
+            <rect key="frame" x="0.0" y="0.0" width="395" height="169"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="395" height="157"/>
+                <rect key="frame" x="0.0" y="0.0" width="395" height="169"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Suw-RX-YLx">
-                        <rect key="frame" x="17" y="20" width="85.5" height="40"/>
+                        <rect key="frame" x="17" y="32" width="85.5" height="40"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="image_profile" translatesAutoresizingMaskIntoConstraints="NO" id="bku-AM-sLk">
                                 <rect key="frame" x="0.0" y="0.0" width="43" height="40"/>
@@ -52,13 +53,13 @@
                         </constraints>
                     </stackView>
                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="faX-06-LC6">
-                        <rect key="frame" x="17" y="80" width="41.5" height="14"/>
+                        <rect key="frame" x="17" y="92" width="41.5" height="14"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="7Qf-3E-m1a">
-                        <rect key="frame" x="17" y="114" width="75" height="24"/>
+                        <rect key="frame" x="17" y="126" width="75" height="24"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Union" translatesAutoresizingMaskIntoConstraints="NO" id="40v-Pj-zMW">
                                 <rect key="frame" x="0.0" y="0.0" width="17" height="16"/>
@@ -81,14 +82,24 @@
                             <constraint firstAttribute="height" constant="24" id="b83-vA-7ZW"/>
                         </constraints>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nYZ-bb-5aq">
+                        <rect key="frame" x="0.0" y="0.0" width="395" height="12"/>
+                        <color key="backgroundColor" name="Ltgray2"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="12" id="h7A-Dq-Vh3"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
                     <constraint firstItem="7Qf-3E-m1a" firstAttribute="top" secondItem="faX-06-LC6" secondAttribute="bottom" constant="20" id="Bzk-c5-iip"/>
+                    <constraint firstAttribute="trailing" secondItem="nYZ-bb-5aq" secondAttribute="trailing" id="HN5-Kx-QES"/>
                     <constraint firstItem="faX-06-LC6" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="17" id="Lbq-Vc-Bi9"/>
                     <constraint firstItem="faX-06-LC6" firstAttribute="top" secondItem="Suw-RX-YLx" secondAttribute="bottom" constant="20" id="MsJ-Q9-yta"/>
                     <constraint firstAttribute="bottom" secondItem="7Qf-3E-m1a" secondAttribute="bottom" constant="19" id="NH8-H7-auh"/>
-                    <constraint firstItem="Suw-RX-YLx" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="20" id="cfp-hL-0OK"/>
+                    <constraint firstItem="nYZ-bb-5aq" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="OWD-qU-h2P"/>
+                    <constraint firstItem="Suw-RX-YLx" firstAttribute="top" secondItem="nYZ-bb-5aq" secondAttribute="bottom" constant="20" id="cfp-hL-0OK"/>
                     <constraint firstItem="7Qf-3E-m1a" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="17" id="glr-Vq-Cu6"/>
+                    <constraint firstItem="nYZ-bb-5aq" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="ymp-Vb-9uz"/>
                     <constraint firstItem="Suw-RX-YLx" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="17" id="zqF-Vm-yxU"/>
                 </constraints>
             </tableViewCellContentView>
@@ -102,5 +113,8 @@
     <resources>
         <image name="Union" width="16.5" height="15"/>
         <image name="image_profile" width="26" height="26"/>
+        <namedColor name="Ltgray2">
+            <color red="0.93300002813339233" green="0.93300002813339233" blue="0.93300002813339233" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
     </resources>
 </document>

--- a/Careerly/Careerly/Screens/Detail/DetailCell/PostDetailTVC.xib
+++ b/Careerly/Careerly/Screens/Detail/DetailCell/PostDetailTVC.xib
@@ -97,7 +97,7 @@
                         </constraints>
                     </imageView>
                     <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="4J5-mh-W08">
-                        <rect key="frame" x="17" y="224" width="121" height="20"/>
+                        <rect key="frame" x="16.999999999999993" y="224" width="121.33333333333331" height="20"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="profile_group" translatesAutoresizingMaskIntoConstraints="NO" id="Lse-dw-X3Q">
                                 <rect key="frame" x="0.0" y="0.0" width="34" height="20"/>
@@ -107,14 +107,13 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="2명이 추천했어요" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hAC-x2-yc2">
-                                <rect key="frame" x="38" y="0.0" width="83" height="20"/>
+                                <rect key="frame" x="37.999999999999993" y="0.0" width="83.333333333333314" height="20"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="width" constant="121" id="VBh-5r-GPl"/>
                             <constraint firstAttribute="height" constant="20" id="qRg-Cs-2DA"/>
                         </constraints>
                     </stackView>
@@ -124,7 +123,7 @@
                         <color key="textColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="1" colorSpace="calibratedRGB"/>
                         <nil key="highlightedColor"/>
                     </label>
-                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="d5m-8e-SuM">
+                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="line" translatesAutoresizingMaskIntoConstraints="NO" id="d5m-8e-SuM">
                         <rect key="frame" x="17" y="201" width="327" height="3"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="327" id="Lzl-zO-A5H"/>
@@ -170,8 +169,9 @@
     </objects>
     <resources>
         <image name="Component 5" width="104.66666412353516" height="17.333333969116211"/>
-        <image name="icon_recommend_detail" width="14" height="18"/>
+        <image name="icon_recommend_detail" width="14" height="17.333333969116211"/>
         <image name="image_profile" width="26" height="26"/>
+        <image name="line" width="328.33334350585938" height="1.3333333730697632"/>
         <image name="profile_group" width="34" height="20.333333969116211"/>
     </resources>
 </document>

--- a/Careerly/Careerly/Screens/Detail/PostDetailViewController.swift
+++ b/Careerly/Careerly/Screens/Detail/PostDetailViewController.swift
@@ -84,8 +84,6 @@ extension PostDetailViewController: UITableViewDataSource{
         case 0:
             guard let cell = postTableView.dequeueReusableCell(withIdentifier: PostDetailTVC.identifier, for: indexPath) as? PostDetailTVC else { return UITableViewCell() }
             
-            //guard let text = postText else { return }
-            //non-void function should return a value
             cell.setData(PostDetailModel(postText: postText ?? ""))
             return cell
         case 1:


### PR DESCRIPTION
## 🌱 작업한 내용
게시글 상세보기 뷰에서 기존 ui와 같지 않은 부분을 수정했습니다 
-  날짜 부분 밑에 밑줄 안보임 
- label 끝 부분이 다 안보임
- 댓글 작성시 다른 cell과의 간격 

## 📸 스크린샷
|    기존    |   변경후   |
| :-------------: | :----------: |
| ![Simulator Screen Shot - iPhone 13 mini - 2022-05-29 at 14 57 51](https://user-images.githubusercontent.com/54045865/170855381-6babfe1f-09c7-4a8e-bf22-aa882b098167.png) | ![Simulator Screen Shot - iPhone 13 mini - 2022-05-29 at 15 26 16](https://user-images.githubusercontent.com/54045865/170855372-f4df7ceb-b46e-45bc-abb2-41974ced00ad.png) |

## 📮 관련 이슈
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->
- Resolved: #20 
